### PR TITLE
Kwalitee and minor doc fix

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ version = 1.06
 [PkgVersion]
 [AutoPrereqs]
 skip = Proc::ProcessTable
+[MetaProvides::Package]
 [OSPrereqs / riscos]
 Proc::ProcessTable = 0.49
 [GithubMeta]

--- a/lib/Proc/Pidfile.pm
+++ b/lib/Proc/Pidfile.pm
@@ -172,7 +172,7 @@ the curent process
 
     my $pp = Proc::Pidfile->new();
     # creates pidfile in default location - /var/run or File::Spec->tmpdir ...
-    my $pidfile = $pp=>pidfile();
+    my $pidfile = $pp->pidfile();
     # tells you where this pidfile is ...
 
     my $pp = Proc::Pidfile->new( silent => 1 );


### PR DESCRIPTION
Added [MetaProvides::Package] to dist.ini to address Kwalitee
suggestion.

Pretty sure fat arrow was not intended in the example for getting
the pidfile, so changed it to -> instead.
